### PR TITLE
votes: rename feature to bonding to better align with usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ build:
 		--wasm target/wasm32-unknown-unknown/release/soroban_votes.wasm \
 		--wasm-out target/wasm32-unknown-unknown/optimized/soroban_votes.wasm
 
-	cargo rustc --manifest-path=contracts/votes/Cargo.toml --crate-type=cdylib --target=wasm32-unknown-unknown --release --features soroban-votes/staking
+	cargo rustc --manifest-path=contracts/votes/Cargo.toml --crate-type=cdylib --target=wasm32-unknown-unknown --release --features soroban-votes/bonding
 	soroban contract optimize \
 		--wasm target/wasm32-unknown-unknown/release/soroban_votes.wasm \
-		--wasm-out target/wasm32-unknown-unknown/optimized/soroban_votes_staking.wasm
+		--wasm-out target/wasm32-unknown-unknown/optimized/soroban_votes_bonding.wasm
 
 	cargo rustc --manifest-path=contracts/governor/Cargo.toml --crate-type=cdylib --target=wasm32-unknown-unknown --release
 	soroban contract optimize \
@@ -37,7 +37,7 @@ clean:
 generate-js:
 	soroban contract bindings typescript --overwrite \
 		--contract-id CBWH54OKUK6U2J2A4J2REJEYB625NEFCHISWXLOPR2D2D6FTN63TJTWN \
-		--wasm ./target/wasm32-unknown-unknown/optimized/soroban_votes_staking.wasm --output-dir ./js/js-votes-staking/ \
+		--wasm ./target/wasm32-unknown-unknown/optimized/soroban_votes_bonding.wasm --output-dir ./js/js-votes-bonding/ \
 		--rpc-url http://localhost:8000 --network-passphrase "Standalone Network ; February 2017" --network Standalone
 	soroban contract bindings typescript --overwrite \
 		--contract-id CBWH54OKUK6U2J2A4J2REJEYB625NEFCHISWXLOPR2D2D6FTN63TJTWN \

--- a/contracts/tests/Cargo.toml
+++ b/contracts/tests/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 soroban-sdk = { workspace = true, features = ["testutils"] }
 sep-41-token = { workspace = true, features = ["testutils"] }
 soroban-governor = { path = "../governor", features = ["testutils"] }
-soroban-votes = { path = "../votes", features = ["testutils", "staking"] }
+soroban-votes = { path = "../votes", features = ["testutils", "bonding"] }

--- a/contracts/tests/src/governor.rs
+++ b/contracts/tests/src/governor.rs
@@ -27,7 +27,7 @@ pub fn create_governor<'a>(
     let governor_address = e.register_contract(None, GovernorContract {});
     let (underlying_token, _) = common::create_stellar_token(e, admin);
     let (vote_address, _) =
-        votes::create_staking_token_votes(e, &underlying_token, &governor_address);
+        votes::create_bonding_token_votes(e, &underlying_token, &governor_address);
     let govenor_client: GovernorContractClient<'a> =
         GovernorContractClient::new(&e, &governor_address);
     govenor_client.initialize(&vote_address, settings);
@@ -49,7 +49,7 @@ pub fn create_governor_wasm<'a>(
     let governor_address = e.register_contract_wasm(None, governor_contract_wasm::WASM);
     let (underlying_token, _) = common::create_stellar_token(e, admin);
     let (vote_address, _) =
-        votes::create_staking_token_votes_wasm(e, &underlying_token, &governor_address);
+        votes::create_bonding_token_votes_wasm(e, &underlying_token, &governor_address);
     let govenor_client: GovernorContractClient<'a> =
         GovernorContractClient::new(&e, &governor_address);
     govenor_client.initialize(&vote_address, settings);

--- a/contracts/tests/src/votes.rs
+++ b/contracts/tests/src/votes.rs
@@ -8,24 +8,24 @@ mod token_votes_wasm {
 }
 pub use token_votes_wasm::Client as SorobanVotesClient;
 
-mod staking_token_votes_wasm {
+mod bonding_token_votes_wasm {
     soroban_sdk::contractimport!(
-        file = "../../target/wasm32-unknown-unknown/optimized/soroban_votes_staking.wasm"
+        file = "../../target/wasm32-unknown-unknown/optimized/soroban_votes_bonding.wasm"
     );
 }
-pub use staking_token_votes_wasm::Client as StakingVotesClient;
+pub use bonding_token_votes_wasm::Client as BondingVotesClient;
 
 /// Create a voting token contract for an underyling token
 ///
 /// ### Arguments
 /// * `token` - The underlying token address
-pub fn create_staking_token_votes<'a>(
+pub fn create_bonding_token_votes<'a>(
     e: &Env,
     token: &Address,
     governor: &Address,
-) -> (Address, StakingVotesClient<'a>) {
+) -> (Address, BondingVotesClient<'a>) {
     let vote_token_id = e.register_contract(None, TokenVotes {});
-    let vote_token_client = StakingVotesClient::new(e, &vote_token_id);
+    let vote_token_client = BondingVotesClient::new(e, &vote_token_id);
     vote_token_client.initialize(
         &token,
         &governor,
@@ -39,13 +39,13 @@ pub fn create_staking_token_votes<'a>(
 ///
 /// ### Arguments
 /// * `token` - The underlying token address
-pub fn create_staking_token_votes_wasm<'a>(
+pub fn create_bonding_token_votes_wasm<'a>(
     e: &Env,
     token: &Address,
     governor: &Address,
-) -> (Address, StakingVotesClient<'a>) {
-    let vote_token_id = e.register_contract_wasm(None, staking_token_votes_wasm::WASM);
-    let vote_token_client = StakingVotesClient::new(e, &vote_token_id);
+) -> (Address, BondingVotesClient<'a>) {
+    let vote_token_id = e.register_contract_wasm(None, bonding_token_votes_wasm::WASM);
+    let vote_token_client = BondingVotesClient::new(e, &vote_token_id);
     vote_token_client.initialize(
         &token,
         &governor,

--- a/contracts/tests/tests/governor/test_cancel.rs
+++ b/contracts/tests/tests/governor/test_cancel.rs
@@ -8,7 +8,7 @@ use soroban_sdk::{
 use tests::{
     env::EnvTestUtils,
     governor::{create_governor, default_governor_settings, default_proposal_data},
-    votes::StakingVotesClient,
+    votes::BondingVotesClient,
 };
 
 #[test]
@@ -23,7 +23,7 @@ fn test_cancel() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_votes: i128 = 1 * 10i128.pow(7);
@@ -90,7 +90,7 @@ fn test_cancel_council() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_votes: i128 = 1 * 10i128.pow(7);
@@ -177,7 +177,7 @@ fn test_cancel_proposal_active() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_mint_amount: i128 = 10_000_000;
@@ -208,7 +208,7 @@ fn test_cancel_unauthorized_address() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_votes: i128 = 1 * 10i128.pow(7);
@@ -239,7 +239,7 @@ fn test_cancel_already_closed() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_votes = 105 * 10i128.pow(7);

--- a/contracts/tests/tests/governor/test_close.rs
+++ b/contracts/tests/tests/governor/test_close.rs
@@ -9,7 +9,7 @@ use soroban_sdk::{
 use tests::{
     env::EnvTestUtils,
     governor::{create_governor, default_governor_settings, default_proposal_data},
-    votes::StakingVotesClient,
+    votes::BondingVotesClient,
 };
 
 #[test]
@@ -27,7 +27,7 @@ fn test_close_successful() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_votes = 105 * 10i128.pow(7);
@@ -103,7 +103,7 @@ fn test_close_defeated_quorum_not_met() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_votes = 99 * 10i128.pow(7); // quorum is 1%
@@ -175,7 +175,7 @@ fn test_close_defeated_threshold_not_met() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_votes = 200 * 10i128.pow(7);
@@ -248,7 +248,7 @@ fn test_close_expired() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_votes = 105 * 10i128.pow(7);
@@ -325,7 +325,7 @@ fn test_close_tracks_quorum_with_counting_type() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_votes = 50 * 10i128.pow(7);
@@ -377,7 +377,7 @@ fn test_close_successful_non_executable() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_votes = 105 * 10i128.pow(7);
@@ -423,7 +423,7 @@ fn test_close_nonexistent_proposal() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_mint_amount: i128 = 10_000_000;
@@ -449,7 +449,7 @@ fn test_close_vote_period_unfinished() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_mint_amount: i128 = 10_000_000;
@@ -481,7 +481,7 @@ fn test_close_already_closed() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_votes = 105 * 10i128.pow(7);

--- a/contracts/tests/tests/governor/test_propose.rs
+++ b/contracts/tests/tests/governor/test_propose.rs
@@ -9,7 +9,7 @@ use soroban_sdk::{
 use tests::{
     env::EnvTestUtils,
     governor::{create_governor, default_governor_settings, default_proposal_data},
-    votes::StakingVotesClient,
+    votes::BondingVotesClient,
 };
 
 #[test]
@@ -23,7 +23,7 @@ fn test_propose_calldata() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_mint_amount: i128 = 10_000_000;
@@ -143,7 +143,7 @@ fn test_propose_calldata_validates() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_mint_amount: i128 = 10_000_000;
@@ -173,7 +173,7 @@ fn test_propose_with_active_proposal() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_mint_amount: i128 = 10_000_000;
@@ -209,7 +209,7 @@ fn test_propose_snapshot() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_mint_amount: i128 = 10_000_000;
@@ -245,7 +245,7 @@ fn test_propose_upgrade() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_mint_amount: i128 = 10_000_000;
@@ -286,7 +286,7 @@ fn test_propose_settings() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_mint_amount: i128 = 10_000_000;
@@ -329,7 +329,7 @@ fn test_propose_settings_validates() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_mint_amount: i128 = 10_000_000;
@@ -360,7 +360,7 @@ fn test_propose_below_proposal_threshold() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_mint_amount: i128 = 999_999;

--- a/contracts/tests/tests/governor/test_vote.rs
+++ b/contracts/tests/tests/governor/test_vote.rs
@@ -9,7 +9,7 @@ use soroban_sdk::{
 use tests::{
     env::EnvTestUtils,
     governor::{create_governor, default_governor_settings, default_proposal_data},
-    votes::StakingVotesClient,
+    votes::BondingVotesClient,
 };
 
 #[test]
@@ -26,7 +26,7 @@ fn test_vote() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let frodo_votes = 2_000 * 10i128.pow(7);
@@ -109,7 +109,7 @@ fn test_vote_user_changes_support() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let frodo_votes = 2_000 * 10i128.pow(7);
@@ -159,7 +159,7 @@ fn test_vote_multiple_users() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let samwise_votes = 1_000 * 10i128.pow(7);
@@ -228,7 +228,7 @@ fn test_vote_nonexistent_proposal() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let frodo_votes = 2_000 * 10i128.pow(7);
@@ -257,7 +257,7 @@ fn test_vote_delay_not_ended() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let frodo_votes = 2_000 * 10i128.pow(7);
@@ -291,7 +291,7 @@ fn test_vote_period_ended() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let frodo_votes = 2_000 * 10i128.pow(7);
@@ -327,7 +327,7 @@ fn test_vote_invalid_support_option() {
     let (governor_address, token_address, votes_address) =
         create_governor(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
 
     let frodo_votes = 2_000 * 10i128.pow(7);

--- a/contracts/tests/tests/test_wasm_happy_path.rs
+++ b/contracts/tests/tests/test_wasm_happy_path.rs
@@ -9,7 +9,7 @@ use tests::{
     env::EnvTestUtils,
     governor::{create_governor_wasm, default_governor_settings, default_proposal_data},
     mocks::create_mock_subcall_contract_wasm,
-    votes::{SorobanVotesClient, StakingVotesClient},
+    votes::{BondingVotesClient, SorobanVotesClient},
 };
 
 const ONE_HOUR: u32 = 60 * 60 / 5;
@@ -31,7 +31,7 @@ fn test_wasm_happy_path() {
     let (governor_address, token_address, votes_address) =
         create_governor_wasm(&e, &bombadil, &settings);
     let token_client = MockTokenClient::new(&e, &token_address);
-    let votes_client = StakingVotesClient::new(&e, &votes_address);
+    let votes_client = BondingVotesClient::new(&e, &votes_address);
     let governor_client = GovernorContractClient::new(&e, &governor_address);
     let (subcall_address, _) =
         create_mock_subcall_contract_wasm(&e, &token_address, &governor_address);

--- a/contracts/tests/tests/votes/test_delegation.rs
+++ b/contracts/tests/tests/votes/test_delegation.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{
 use tests::{
     common::create_stellar_token,
     env::EnvTestUtils,
-    votes::{create_soroban_token_votes_wasm, create_staking_token_votes},
+    votes::{create_bonding_token_votes, create_soroban_token_votes_wasm},
 };
 
 #[test]
@@ -21,7 +21,7 @@ fn test_delegation() {
     let governor = Address::generate(&e);
 
     let (token_id, token_client) = create_stellar_token(&e, &bombadil);
-    let (votes_id, votes_client) = create_staking_token_votes(&e, &token_id, &governor);
+    let (votes_id, votes_client) = create_bonding_token_votes(&e, &token_id, &governor);
 
     votes_client.set_vote_sequence(&(e.ledger().sequence() + 100 - 1));
 
@@ -264,7 +264,7 @@ fn test_delegation_to_current_delegate() {
     let governor = Address::generate(&e);
 
     let (token_id, _) = create_stellar_token(&e, &bombadil);
-    let (_, votes_client) = create_staking_token_votes(&e, &token_id, &governor);
+    let (_, votes_client) = create_bonding_token_votes(&e, &token_id, &governor);
 
     votes_client.delegate(&samwise, &frodo);
 

--- a/contracts/tests/tests/votes/test_deposit.rs
+++ b/contracts/tests/tests/votes/test_deposit.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{
     testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events},
     vec, Address, Env, IntoVal, Symbol, Val,
 };
-use tests::{common::create_stellar_token, env::EnvTestUtils, votes::create_staking_token_votes};
+use tests::{common::create_stellar_token, env::EnvTestUtils, votes::create_bonding_token_votes};
 
 #[test]
 fn test_deposit() {
@@ -16,7 +16,7 @@ fn test_deposit() {
     let governor = Address::generate(&e);
 
     let (token_id, token_client) = create_stellar_token(&e, &bombadil);
-    let (votes_id, votes_client) = create_staking_token_votes(&e, &token_id, &governor);
+    let (votes_id, votes_client) = create_bonding_token_votes(&e, &token_id, &governor);
 
     let initial_balance = 100_000 * 10i128.pow(7);
     token_client.mint(&samwise, &initial_balance);
@@ -96,7 +96,7 @@ fn test_deposit_negative_amount() {
     let governor = Address::generate(&e);
 
     let (token_id, token_client) = create_stellar_token(&e, &bombadil);
-    let (_, votes_client) = create_staking_token_votes(&e, &token_id, &governor);
+    let (_, votes_client) = create_bonding_token_votes(&e, &token_id, &governor);
 
     let initial_balance = 100_000 * 10i128.pow(7);
     token_client.mint(&samwise, &initial_balance);

--- a/contracts/tests/tests/votes/test_emissions.rs
+++ b/contracts/tests/tests/votes/test_emissions.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{
     vec, Address, Env, IntoVal, Symbol,
 };
 use tests::{
-    common::create_stellar_token, env::EnvTestUtils, votes::create_staking_token_votes_wasm,
+    common::create_stellar_token, env::EnvTestUtils, votes::create_bonding_token_votes_wasm,
 };
 
 #[test]
@@ -19,7 +19,7 @@ fn test_emissions() {
     let governor = Address::generate(&e);
 
     let (token_id, token_client) = create_stellar_token(&e, &bombadil);
-    let (votes_id, votes_client) = create_staking_token_votes_wasm(&e, &token_id, &governor);
+    let (votes_id, votes_client) = create_bonding_token_votes_wasm(&e, &token_id, &governor);
 
     let mut balance_samwise = 0;
     let mut balance_frodo = 0;

--- a/contracts/tests/tests/votes/test_get_past.rs
+++ b/contracts/tests/tests/votes/test_get_past.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{testutils::Address as _, Address, Env, Error};
 use tests::{
     common::create_stellar_token,
     env::EnvTestUtils,
-    votes::{create_soroban_token_votes_wasm, create_staking_token_votes},
+    votes::{create_bonding_token_votes, create_soroban_token_votes_wasm},
     ONE_DAY_LEDGERS,
 };
 
@@ -20,7 +20,7 @@ fn test_get_past() {
     let governor = Address::generate(&e);
 
     let (token_id, token_client) = create_stellar_token(&e, &bombadil);
-    let (_, votes_client) = create_staking_token_votes(&e, &token_id, &governor);
+    let (_, votes_client) = create_bonding_token_votes(&e, &token_id, &governor);
 
     // setup vote ledgers - do a ledger before each action to verify the actions
     // occuring after the vote starts are recorded properly
@@ -172,7 +172,7 @@ fn test_get_past_same_sequence_as_ledger() {
     let governor = Address::generate(&e);
 
     let (token_id, token_client) = create_stellar_token(&e, &bombadil);
-    let (_, votes_client) = create_staking_token_votes(&e, &token_id, &governor);
+    let (_, votes_client) = create_bonding_token_votes(&e, &token_id, &governor);
 
     let cur_ledger = e.ledger().sequence();
     votes_client.set_vote_sequence(&(cur_ledger + 99));

--- a/contracts/tests/tests/votes/test_token_actions.rs
+++ b/contracts/tests/tests/votes/test_token_actions.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{
 use tests::{
     common::create_stellar_token,
     env::EnvTestUtils,
-    votes::{create_soroban_token_votes_wasm, create_staking_token_votes},
+    votes::{create_bonding_token_votes, create_soroban_token_votes_wasm},
 };
 
 #[test]
@@ -21,7 +21,7 @@ fn initialize_already_initialized() {
     let governor = Address::generate(&e);
 
     let (token_id, _) = create_stellar_token(&e, &bombadil);
-    let (_, votes_client) = create_staking_token_votes(&e, &token_id, &governor);
+    let (_, votes_client) = create_bonding_token_votes(&e, &token_id, &governor);
 
     votes_client.initialize(
         &Address::generate(&e),

--- a/contracts/tests/tests/votes/test_withdraw.rs
+++ b/contracts/tests/tests/votes/test_withdraw.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{
     testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events},
     vec, Address, Env, IntoVal, Symbol, Val,
 };
-use tests::{common::create_stellar_token, env::EnvTestUtils, votes::create_staking_token_votes};
+use tests::{common::create_stellar_token, env::EnvTestUtils, votes::create_bonding_token_votes};
 
 #[test]
 fn test_withdraw() {
@@ -16,7 +16,7 @@ fn test_withdraw() {
     let governor = Address::generate(&e);
 
     let (token_id, token_client) = create_stellar_token(&e, &bombadil);
-    let (votes_id, votes_client) = create_staking_token_votes(&e, &token_id, &governor);
+    let (votes_id, votes_client) = create_bonding_token_votes(&e, &token_id, &governor);
 
     votes_client.set_vote_sequence(&(e.ledger().sequence() + 1000 - 1));
 
@@ -114,7 +114,7 @@ fn test_withdraw_full_balance() {
     let governor = Address::generate(&e);
 
     let (token_id, token_client) = create_stellar_token(&e, &bombadil);
-    let (votes_id, votes_client) = create_staking_token_votes(&e, &token_id, &governor);
+    let (votes_id, votes_client) = create_bonding_token_votes(&e, &token_id, &governor);
 
     let initial_balance = 100_000 * 10i128.pow(7);
     token_client.mint(&samwise, &initial_balance);
@@ -145,7 +145,7 @@ fn test_withdraw_negative_amount() {
     let governor = Address::generate(&e);
 
     let (token_id, token_client) = create_stellar_token(&e, &bombadil);
-    let (_, votes_client) = create_staking_token_votes(&e, &token_id, &governor);
+    let (_, votes_client) = create_bonding_token_votes(&e, &token_id, &governor);
 
     let initial_balance = 100_000 * 10i128.pow(7);
     token_client.mint(&samwise, &initial_balance);
@@ -171,7 +171,7 @@ fn test_withdraw_more_than_balance() {
     let governor = Address::generate(&e);
 
     let (token_id, token_client) = create_stellar_token(&e, &bombadil);
-    let (_, votes_client) = create_staking_token_votes(&e, &token_id, &governor);
+    let (_, votes_client) = create_bonding_token_votes(&e, &token_id, &governor);
 
     let initial_balance = 100_000 * 10i128.pow(7);
     token_client.mint(&samwise, &initial_balance);

--- a/contracts/votes/Cargo.toml
+++ b/contracts/votes/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 
 [features]
 testutils = ["soroban-sdk/testutils"]
-staking = []
+bonding = []
 sep-0041 = []
 
 [dependencies]

--- a/contracts/votes/src/balance.rs
+++ b/contracts/votes/src/balance.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use soroban_sdk::{panic_with_error, Address, Env};
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 use crate::emissions;
 
 /// Add tokens to an address's balance and update emissions and voting power
@@ -23,7 +23,7 @@ pub fn mint_balance(e: &Env, to: &Address, amount: i128) {
         let total_supply_checkpoint = storage::get_total_supply(e);
         let (_, mut supply) = total_supply_checkpoint.to_checkpoint_data();
 
-        #[cfg(feature = "staking")]
+        #[cfg(feature = "bonding")]
         emissions::update_emissions(e, supply, to, balance);
 
         supply = supply
@@ -65,7 +65,7 @@ pub fn burn_balance(e: &Env, from: &Address, amount: i128) {
     let total_supply_checkpoint = storage::get_total_supply(e);
     let (_, mut supply) = total_supply_checkpoint.to_checkpoint_data();
 
-    #[cfg(feature = "staking")]
+    #[cfg(feature = "bonding")]
     emissions::update_emissions(e, supply, from, balance);
 
     supply -= amount;
@@ -98,7 +98,7 @@ pub fn transfer_balance(e: &Env, from: &Address, to: &Address, amount: i128) {
     }
     let to_balance = storage::get_balance(e, to);
 
-    #[cfg(feature = "staking")]
+    #[cfg(feature = "bonding")]
     {
         let total_supply_checkpoint = storage::get_total_supply(e);
         let (_, supply) = total_supply_checkpoint.to_checkpoint_data();

--- a/contracts/votes/src/constants.rs
+++ b/contracts/votes/src/constants.rs
@@ -7,5 +7,5 @@ pub(crate) const MAX_CHECKPOINT_AGE_LEDGERS: u32 = 8 * ONE_DAY_LEDGERS;
 /// The maximum number of ledgers a proposal can exist for.
 pub(crate) const MAX_PROPOSAL_AGE_LEDGERS: u32 = 31 * ONE_DAY_LEDGERS;
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 pub(crate) const SCALAR_7: i128 = 1_0000000;

--- a/contracts/votes/src/contract.rs
+++ b/contracts/votes/src/contract.rs
@@ -22,19 +22,19 @@ use sep_41_token::{Token, TokenEvents};
 #[cfg(feature = "sep-0041")]
 use crate::allowance::{create_allowance, spend_allowance};
 
-// Staking Feature imports
+// Bonding Feature imports
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 use crate::{
     emissions::{claim_emissions, set_emissions},
-    votes::Staking,
+    votes::Bonding,
 };
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 use soroban_sdk::token::TokenClient;
 
-// Soroban Only (SEP-0041 and Staking not enabled) Feature imports
+// Soroban Only (SEP-0041 and Bonding not enabled) Feature imports
 
-#[cfg(all(feature = "sep-0041", not(feature = "staking")))]
+#[cfg(all(feature = "sep-0041", not(feature = "bonding")))]
 use crate::votes::SorobanOnly;
 
 #[contract]
@@ -94,7 +94,7 @@ impl Token for TokenVotes {
         balance::burn_balance(&e, &from, amount);
 
         // burn underlying from the tokens held by this contract
-        #[cfg(feature = "staking")]
+        #[cfg(feature = "bonding")]
         TokenClient::new(&e, &storage::get_token(&e)).burn(&e.current_contract_address(), &amount);
 
         TokenEvents::burn(&e, from, amount);
@@ -109,7 +109,7 @@ impl Token for TokenVotes {
         balance::burn_balance(&e, &from, amount);
 
         // burn underlying from the tokens held by this contract
-        #[cfg(feature = "staking")]
+        #[cfg(feature = "bonding")]
         TokenClient::new(&e, &storage::get_token(&e)).burn(&e.current_contract_address(), &amount);
 
         TokenEvents::burn(&e, from, amount);
@@ -228,9 +228,9 @@ impl Votes for TokenVotes {
     }
 }
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 #[contractimpl]
-impl Staking for TokenVotes {
+impl Bonding for TokenVotes {
     fn initialize(e: Env, token: Address, governor: Address, name: String, symbol: String) {
         if storage::get_is_init(&e) {
             panic_with_error!(e, TokenVotesError::AlreadyInitializedError);
@@ -316,7 +316,7 @@ impl Staking for TokenVotes {
     }
 }
 
-#[cfg(all(feature = "sep-0041", not(feature = "staking")))]
+#[cfg(all(feature = "sep-0041", not(feature = "bonding")))]
 #[contractimpl]
 impl SorobanOnly for TokenVotes {
     fn initialize(

--- a/contracts/votes/src/emissions.rs
+++ b/contracts/votes/src/emissions.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "staking")]
+#![cfg(feature = "bonding")]
 
 use soroban_fixed_point_math::FixedPoint;
 use soroban_sdk::{panic_with_error, unwrap::UnwrapOptimized, Address, Env};

--- a/contracts/votes/src/events.rs
+++ b/contracts/votes/src/events.rs
@@ -23,13 +23,13 @@ impl TokenVotesEvents {
         e.events().publish(topics, (old_votes, new_votes));
     }
 
-    #[cfg(all(feature = "sep-0041", not(feature = "staking")))]
+    #[cfg(all(feature = "sep-0041", not(feature = "bonding")))]
     pub fn set_admin(e: &Env, admin: Address, new_admin: Address) {
         let topics = (Symbol::new(e, "set_admin"), admin);
         e.events().publish(topics, new_admin);
     }
 
-    #[cfg(feature = "staking")]
+    #[cfg(feature = "bonding")]
     /// Emitted when an account deposits tokens into the votes contract
     ///
     /// - topics - `["deposit", account: Address]`
@@ -39,7 +39,7 @@ impl TokenVotesEvents {
         e.events().publish(topics, amount);
     }
 
-    #[cfg(feature = "staking")]
+    #[cfg(feature = "bonding")]
     /// Emitted when an account withdraws tokens from the votes contract
     ///
     /// - topics - `["withdraw", account: Address]`
@@ -49,7 +49,7 @@ impl TokenVotesEvents {
         e.events().publish(topics, amount);
     }
 
-    #[cfg(feature = "staking")]
+    #[cfg(feature = "bonding")]
     /// Emitted when an account claims emissions
     ///
     /// - topics - `["claim", account: Address]`
@@ -59,7 +59,7 @@ impl TokenVotesEvents {
         e.events().publish(topics, amount);
     }
 
-    #[cfg(feature = "staking")]
+    #[cfg(feature = "bonding")]
     /// Emitted when a new emission configuration is set
     ///
     /// - topics - `["set_emissions", eps: u64, expiration: u64]`

--- a/contracts/votes/src/lib.rs
+++ b/contracts/votes/src/lib.rs
@@ -12,7 +12,7 @@ mod constants;
 mod contract;
 mod error;
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 mod emissions;
 
 mod events;

--- a/contracts/votes/src/storage.rs
+++ b/contracts/votes/src/storage.rs
@@ -21,14 +21,14 @@ const TOTAL_SUPPLY_KEY: Symbol = symbol_short!("SUPPLY");
 const TOTAL_SUPPLY_CHECK_KEY: Symbol = symbol_short!("SPLYCHECK");
 const VOTE_LEDGERS_KEY: Symbol = symbol_short!("VOTE_SEQ");
 
-#[cfg(all(feature = "sep-0041", not(feature = "staking")))]
+#[cfg(all(feature = "sep-0041", not(feature = "bonding")))]
 const ADMIN_KEY: Symbol = symbol_short!("ADMIN");
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 const TOKEN_KEY: Symbol = symbol_short!("TOKEN");
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 const EMIS_CONFIG: Symbol = symbol_short!("EMIS_CFG");
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 const EMIS_DATA: Symbol = symbol_short!("EMIS_DATA");
 
 #[derive(Clone)]
@@ -54,7 +54,7 @@ pub enum DataKey {
     Delegate(Address),
 }
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 #[derive(Clone)]
 #[contracttype]
 pub struct EmisKey(Address);
@@ -69,7 +69,7 @@ pub struct TokenMetadata {
     pub symbol: String,
 }
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 // The emission configuration
 #[derive(Clone)]
 #[contracttype]
@@ -78,7 +78,7 @@ pub struct EmissionConfig {
     pub eps: u64,
 }
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 // The emission data
 #[derive(Clone)]
 #[contracttype]
@@ -87,7 +87,7 @@ pub struct EmissionData {
     pub last_time: u64,
 }
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 // The emission data for a user
 #[derive(Clone)]
 #[contracttype]
@@ -174,24 +174,24 @@ pub fn set_metadata(e: &Env, metadata: &TokenMetadata) {
 
 // --- Admin
 
-#[cfg(all(feature = "sep-0041", not(feature = "staking")))]
+#[cfg(all(feature = "sep-0041", not(feature = "bonding")))]
 pub fn get_admin(e: &Env) -> Address {
     e.storage().instance().get(&ADMIN_KEY).unwrap_optimized()
 }
 
-#[cfg(all(feature = "sep-0041", not(feature = "staking")))]
+#[cfg(all(feature = "sep-0041", not(feature = "bonding")))]
 pub fn set_admin(e: &Env, address: &Address) {
     e.storage().instance().set(&ADMIN_KEY, address);
 }
 
 // --- Wrapped Token
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 pub fn get_token(e: &Env) -> Address {
     e.storage().instance().get(&TOKEN_KEY).unwrap_optimized()
 }
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 pub fn set_token(e: &Env, address: &Address) {
     e.storage().instance().set(&TOKEN_KEY, address);
 }
@@ -383,7 +383,7 @@ pub fn set_voting_units_checkpoints(e: &Env, address: &Address, balance: &Vec<u1
 
 // Emission config
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 pub fn get_emission_config(e: &Env) -> Option<EmissionConfig> {
     get_persistent_default(
         e,
@@ -394,7 +394,7 @@ pub fn get_emission_config(e: &Env) -> Option<EmissionConfig> {
     )
 }
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 pub fn set_emission_config(e: &Env, config: &EmissionConfig) {
     e.storage().persistent().set(&EMIS_CONFIG, config);
     e.storage().persistent().extend_ttl(
@@ -406,7 +406,7 @@ pub fn set_emission_config(e: &Env, config: &EmissionConfig) {
 
 // Emission data
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 pub fn get_emission_data(e: &Env) -> Option<EmissionData> {
     get_persistent_default(
         e,
@@ -417,7 +417,7 @@ pub fn get_emission_data(e: &Env) -> Option<EmissionData> {
     )
 }
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 pub fn set_emission_data(e: &Env, config: &EmissionData) {
     e.storage().persistent().set(&EMIS_DATA, config);
     e.storage().persistent().extend_ttl(
@@ -429,7 +429,7 @@ pub fn set_emission_data(e: &Env, config: &EmissionData) {
 
 // User emission data
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 pub fn get_user_emission_data(e: &Env, user: &Address) -> Option<UserEmissionData> {
     get_persistent_default(
         e,
@@ -440,7 +440,7 @@ pub fn get_user_emission_data(e: &Env, user: &Address) -> Option<UserEmissionDat
     )
 }
 
-#[cfg(feature = "staking")]
+#[cfg(feature = "bonding")]
 pub fn set_user_emission_data(e: &Env, user: &Address, data: &UserEmissionData) {
     let key = EmisKey(user.clone());
     e.storage().persistent().set(&key, data);

--- a/contracts/votes/src/votes.rs
+++ b/contracts/votes/src/votes.rs
@@ -53,9 +53,9 @@ pub trait Votes {
     fn delegate(e: Env, account: Address, delegatee: Address);
 }
 
-#[cfg(feature = "staking")]
-pub trait Staking {
-    /// Setup the votes contract
+#[cfg(feature = "bonding")]
+pub trait Bonding {
+    /// Setup the bonding votes contract
     ///
     /// ### Arguments
     /// * `token` - The address of the underlying token contract
@@ -117,7 +117,7 @@ pub trait Staking {
     fn symbol(env: Env) -> String;
 }
 
-#[cfg(all(feature = "sep-0041", not(feature = "staking")))]
+#[cfg(all(feature = "sep-0041", not(feature = "bonding")))]
 pub trait SorobanOnly {
     /// Setup the votes contract
     ///


### PR DESCRIPTION
Rename the `staking` feature to `bonding` as this is likely the closest we can get to the intended usage of the feature. Staking felt inappropriate because no funds were at risk and no yield was possible. Wrapping felt inappropriate because the vote token was intended to be non-transferrable. Bonding seems the best as it implies some action being taken to participate in governance.
  * I opted to keep `deposit` and `withdraw` as the function names for the bonding token. I still think they are the best descriptors about what is happening and what to expect with regards to underlying token actions taking place during the transaction. 